### PR TITLE
Remove previous results before starting crawl

### DIFF
--- a/.github/workflows/crawl.yml
+++ b/.github/workflows/crawl.yml
@@ -12,7 +12,11 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - run: ./crawl.sh
+      - name: Remove previous crawl results
+        run: rm -r www.consumerfinance.gov
+
+      - name: Run the crawl script
+        run: ./crawl.sh
 
       - name: Commit crawl results back to GitHub
         uses: EndBug/add-and-commit@v4


### PR DESCRIPTION
If we don't remove the previous crawl, the crawler will skip any pages it has downloaded before, (because of the `--no-clobber` option in `crawl.sh`). By removing `/www.consumerfinance.gov`, we ensure that we do a full crawl every time.