### PR TITLE
Temporary: try continuing even if crawl fails

### DIFF
--- a/.github/workflows/crawl.yml
+++ b/.github/workflows/crawl.yml
@@ -17,6 +17,7 @@ jobs:
 
       - name: Run the crawl script
         run: ./crawl.sh
+        continue-on-error: true
 
       - name: Commit crawl results back to GitHub
         uses: EndBug/add-and-commit@v4

--- a/crawl.sh
+++ b/crawl.sh
@@ -8,7 +8,7 @@ time wget \
     --reject '*.css,*.doc,*.docx,*.gif,*.ico,*.jpg,*.js,*.mp3,*.pdf,*.png,*.txt,*.wav,*.woff,*.woff2,*.xls,*xlsx,*.zip' \
     --reject-regex "topics=|authors=|categories=|filter_blog_category=|ext_url=|search_field=|issuer_name=" \
     --recursive \
-    --level=inf \
+    --level=140 \
     --trust-server-names \
     --no-verbose \
     --no-clobber \


### PR DESCRIPTION
Not sure why this step [is returning exit code 3](https://github.com/cfpb/crawl-cfgov/runs/1229851189?check_suite_focus=true) even though the crawl seems to succeed:

```
FINISHED --2020-10-09 10:36:11--
Total wall clock time: 4h 15m 50s
Downloaded: 12368 files, 1.8G in 2h 22m 0s (225 KB/s)

real	255m50.444s
user	0m29.428s
sys	0m16.115s
Error: Process completed with exit code 3.
```

Let's experiment with [`continue-on-error`](https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-syntax-for-github-actions#jobsjob_idcontinue-on-error).