### PR TITLE
Use diff summary as commit message for crawl results

### DIFF
--- a/.github/workflows/crawl.yml
+++ b/.github/workflows/crawl.yml
@@ -20,9 +20,7 @@ jobs:
         run: ./crawl.sh
 
       - name: Commit crawl results back to GitHub
-        uses: EndBug/add-and-commit@v4
         if: always()
-        with:
-          add: www.consumerfinance.gov
+        run: ./commit_results.sh
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/crawl.yml
+++ b/.github/workflows/crawl.yml
@@ -19,8 +19,16 @@ jobs:
       - name: Run the crawl script
         run: ./crawl.sh
 
+      - name: Prepare COMMIT_MESSAGE variable
+        run: ./generate_summary.sh
+
       - name: Commit crawl results back to GitHub
         if: always()
-        run: ./commit_results.sh
+        uses: EndBug/add-and-commit
+        with:
+          add: 'www.consumerfinance.gov'
+          author_name: Automated
+          author_email: actions@users.noreply.github.com
+          message: $COMMIT_MESSAGE
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/commit_results.sh
+++ b/commit_results.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+git add -A www.consumerfinance.gov
+git diff --staged --compact-summary --no-color > summary.txt
+git commit --author="Automated <actions@users.noreply.github.com>" \
+       --file summary.txt
+git push

--- a/commit_results.sh
+++ b/commit_results.sh
@@ -1,6 +1,0 @@
-#!/usr/bin/env bash
-git add -A www.consumerfinance.gov
-git diff --staged --compact-summary --no-color > summary.txt
-git commit --author="Automated <actions@users.noreply.github.com>" \
-       --file summary.txt
-git push

--- a/crawl.sh
+++ b/crawl.sh
@@ -9,7 +9,7 @@ time wget \
     --accept html \
     --reject-regex "topics=|authors=|categories=|filter_blog_category=|ext_url=|search_field=|issuer_name=" \
     --recursive \
-    --level=5 \
+    --level=4 \
     --trust-server-names \
     --no-verbose \
     --no-clobber \

--- a/generate_summary.sh
+++ b/generate_summary.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+# Generate a summary of the crawl results into message.txt
+git add -A www.consumerfinance.gov
+git diff --staged --compact-summary --no-color > message.txt
+git reset .
+
+# Follow these instructions to set the value of the COMMIT_MESSAGE
+# environment variable and save it to the GitHub Actions environment:
+# https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-commands-for-github-actions#setting-an-environment-variable
+echo 'COMMIT_MESSAGE<<EOF' >> $GITHUB_ENV
+echo $(cat message.txt) >> $GITHUB_ENV
+echo 'EOF' >> $GITHUB_ENV


### PR DESCRIPTION
Here's a first attempt at giving a more useful commit message to the automated commits that contain crawl results. It uses `git diff --staged --compact-summary`, which shows which files were added, deleted, or modified, and the magnitude of changes to each file. It also contains a summary line like `65 files changed, 11542 insertions(+), 2566 deletions(-)`. 

This should be an improvement over the current commit messages (which are just "Commit from GitHub Actions"), but we can probably improve them further with input from users of the archive.