### PR TITLE
Remove script tags from crawl results

### DIFF
--- a/.github/workflows/crawl.yml
+++ b/.github/workflows/crawl.yml
@@ -20,8 +20,8 @@ jobs:
         run: ./crawl.sh
         continue-on-error: true
 
-      - name: Remove <script> tags from crawl results
-        run: find www.consumerfinance.gov -type f -exec sed -f 'sed/remove_scripts.sed' -i '' {} \;
+      - name: Remove <script> tags and blank lines from crawl results
+        run: ./transform_results.sh
         continue-on-error: true
 
       - name: Prepare COMMIT_MESSAGE variable

--- a/.github/workflows/crawl.yml
+++ b/.github/workflows/crawl.yml
@@ -20,6 +20,10 @@ jobs:
         run: ./crawl.sh
         continue-on-error: true
 
+      - name: Remove <script> tags from crawl results
+        run: find www.consumerfinance.gov -type f -exec sed -f 'sed/remove_scripts.sed' -i '' {} \;
+        continue-on-error: true
+
       - name: Prepare COMMIT_MESSAGE variable
         run: ./generate_summary.sh
         continue-on-error: true

--- a/README.md
+++ b/README.md
@@ -7,6 +7,14 @@ This can serve as a resource when answering questions about how the site changes
   - **Technology**: Uses `wget` to crawl the site and download HTML.
   - **Status**:  See the [CHANGELOG](CHANGELOG.md).
 
+## The archive
+
+The archive of consumerfinance.gov is contained in the `www.consumerfinance.gov` directory of this repo.
+It contains an HTML download of each page it crawls.
+The archive does not download any CSS, JavaScript, or images associated with the pages.
+It also does not contain any PDF, CSV, or other supplementary files linked from consumerfinance.gov.
+The HTML is modified before being archived to remove `<script>` tags, since these are usually minified and would not be useful for analysis.
+
 ## Dependencies
 
 This project uses [`wget`](https://www.gnu.org/software/wget/) to crawl consumerfinance.gov and download the HTML.
@@ -20,7 +28,7 @@ To get a copy of the consumerfinance.gov archive or run a crawl on your computer
 
 To view the consumerfinance.gov archive, you can browse the history of this repo here on github.com, or clone this repository.
 
-To run a crawl on your computer, `cd` into the root of this project and use the following command: `./crawl.sh`.
+To run a crawl from your computer, `cd` into the root of this project and use the following command: `./crawl.sh`.
 A full crawl usually takes over two hours.
 To modify the parameters of the crawl, such as the target domain or which pages to include, edit `crawl.sh`.
 

--- a/sed/remove_blank_lines.sed
+++ b/sed/remove_blank_lines.sed
@@ -1,0 +1,6 @@
+#########
+# This sed command will remove all lines that are empty or only contain whitespace
+#########
+
+#  delete blank lines
+/^[[:space:]]*$/d

--- a/sed/remove_scripts.sed
+++ b/sed/remove_scripts.sed
@@ -1,0 +1,18 @@
+#########
+# This sed command will remove all <script> tags and their contents from an html file
+#########
+
+# delete script tags that start and end on the same line
+s/<script.*<\/script>//g
+
+# delete any entire lines that are between the opening and closing script tag
+/<script/,/<\/script>/{/<script/!{/<\/script>/!d;};}
+
+# on lines where a script tag opens but doesn't close, delete the opening tag and everything following it
+s/<script.*//g
+
+# on lines where a script tag closes but doesn't open, delete the closing tag and everything before it
+s/.*<\/script>//g
+
+#  delete blank lines
+/^[[:space:]]*$/d

--- a/sed/remove_scripts.sed
+++ b/sed/remove_scripts.sed
@@ -13,6 +13,3 @@ s/<script.*//g
 
 # on lines where a script tag closes but doesn't open, delete the closing tag and everything before it
 s/.*<\/script>//g
-
-#  delete blank lines
-/^[[:space:]]*$/d

--- a/sed/sample-expected-output.html
+++ b/sed/sample-expected-output.html
@@ -1,0 +1,22 @@
+<html>
+  <head>
+        <meta charset="utf-8">
+        foo
+        <meta charset="utf-8">
+        foo
+        <meta charset="utf-8">
+  <div id="something"></div>
+        foo
+bar
+  </head>
+  <body>
+        <meta charset="utf-8">
+        foo
+        <meta charset="utf-8">
+        foo
+        <meta charset="utf-8">
+  <div id="something"></div>
+        foo
+bar
+  </body>
+</html>

--- a/sed/sample-expected-output.html
+++ b/sed/sample-expected-output.html
@@ -1,3 +1,10 @@
+<test>
+Test the sed script with the following commmand. The diff should be empty.
+  <code>
+      sed -f remove_scripts.sed sample-w-scripts.html > sample-output.html
+      diff sample-output.html sample-expected-output.html
+  </code>
+</test>
 <html>
   <head>
         <meta charset="utf-8">

--- a/sed/sample-expected-output.html
+++ b/sed/sample-expected-output.html
@@ -1,7 +1,7 @@
 <test>
 Test the sed script with the following commmand. The diff should be empty.
   <code>
-      sed -f remove_scripts.sed sample-w-scripts.html > sample-output.html
+      sed -f remove_scripts.sed -f remove_blank_lines.sed sample-w-scripts.html > sample-output.html
       diff sample-output.html sample-expected-output.html
   </code>
 </test>

--- a/sed/sample-w-scripts.html
+++ b/sed/sample-w-scripts.html
@@ -1,3 +1,11 @@
+<test>
+Test the sed script with the following commmand. The diff should be empty.
+  <code>
+      sed -f remove_scripts.sed sample-w-scripts.html > sample-output.html
+      diff sample-output.html sample-expected-output.html
+  </code>
+</test>
+
 <html>
   <head>
         <meta charset="utf-8"><script>(thing+thing=thing)</script>

--- a/sed/sample-w-scripts.html
+++ b/sed/sample-w-scripts.html
@@ -1,0 +1,32 @@
+<html>
+  <head>
+        <meta charset="utf-8"><script>(thing+thing=thing)</script>
+        foo
+        <meta charset="utf-8"><script>(thing+thing=thing)</script>
+        foo
+        <meta charset="utf-8"><script>(thing+thing=thing)</script>
+        <script> console.log("bar) </script>
+  <div id="something"></div>
+        <script>
+                // Multiple Lines script
+                // Blah blah
+        </script>
+        foo<script> //Some
+        console.log("script")</script>bar
+  </head>
+  <body>
+        <meta charset="utf-8"><script type="text/javascript">(thing+thing=thing)</script>
+        foo
+        <meta charset="utf-8"><script type="text/javascript">(thing+thing=thing)</script>
+        foo
+        <meta charset="utf-8"><script type="text/javascript">(thing+thing=thing)</script>
+        <script type="text/javascript"> console.log("bar) </script>
+  <div id="something"></div>
+        <script type="text/javascript">
+                // Multiple Lines script
+                // Blah blah
+        </script>
+        foo<script type="text/javascript"> //Some
+        console.log("script")</script>bar
+  </body>
+</html>

--- a/sed/sample-w-scripts.html
+++ b/sed/sample-w-scripts.html
@@ -1,7 +1,7 @@
 <test>
 Test the sed script with the following commmand. The diff should be empty.
   <code>
-      sed -f remove_scripts.sed sample-w-scripts.html > sample-output.html
+      sed -f remove_scripts.sed -f remove_blank_lines.sed sample-w-scripts.html > sample-output.html
       diff sample-output.html sample-expected-output.html
   </code>
 </test>

--- a/transform_results.sh
+++ b/transform_results.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+# for each file in the www.consumerfinance.gov directory, run the given sed commands on it
+find www.consumerfinance.gov -type f \
+    -exec sed -f 'sed/remove_scripts.sed' -f 'sed/remove_blank_lines.sed' -i '' {} \;


### PR DESCRIPTION
Addresses #6. 

Use `sed` to remove `<script>` tags from all html pages in the crawl results. This will reduce churn in the crawl results, so we'll have smaller, more meaningful diffs. We won't be able to compare minified JS over time.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [ ] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [x] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: