### PR TITLE
Overwrite gzipped logs even if they exist

### DIFF
--- a/.github/workflows/crawl.yml
+++ b/.github/workflows/crawl.yml
@@ -28,7 +28,7 @@ jobs:
 
       - name: Commit crawl results back to GitHub
         run: |
-          gzip *.log
+          gzip -f *.log
           git add .
           git config user.email actions@users.noreply.github.com
           git config user.name Automated


### PR DESCRIPTION
#10 introduced a bug where gzipping the log files would fail if they already existed. See [this Actions run on my fork](https://github.com/chosak/crawl-cfgov/runs/1343454671?check_suite_focus=true) for an example where this failed.

This change modifies the logic to overwrite any existing gzipped logs.