### PR TITLE
Reject non-HTML instead of accepting only HTML

### DIFF
--- a/crawl.sh
+++ b/crawl.sh
@@ -62,7 +62,7 @@ time wget \
     --execute robots=off \
     --follow-tags=a \
     --limit-rate=1m \
-    --accept html \
+    --reject '*.css,*.csv,*.CSV,*.doc,*.docx,*.epub,*.gif,*.ico,*.jpg,*.js,*.mp3,*.pdf,*.PDF,*.png,*.pptx,*.tmp,*.txt,*.wav,*.woff,*.woff2,*.xls,*xlsx,*.xml,*.zip' \
     --reject-regex "topics=|authors=|categories=|filter_blog_category=|ext_url=|search_field=|issuer_name=" \
     --recursive \
     --level="$depth" \


### PR DESCRIPTION
Trying to accept only files that end in .html causes problems when:

1. Links on a page don't end in a trailing slash (e.g. /foo/bar), and wget interprets the link of being of type "bar", and thus rejects it (see https://github.com/cfpb/crawl-cfgov/issues/9#issuecomment-719752504).
2. Long URLs get truncated when saved as files and thus don't end in .html. These get deleted by wget (see #13).

This change restores [old behavior](https://github.com/cfpb/crawl-cfgov/commit/2ab81ec749ce55fc105b93e2934e927ff9f75c21) that provided an explicit rejectlist instead of only accepting html. This is a little suboptimal; it would be nice not to have to list out a potentially-ever-growing list of file extensions, but I'm not sure of a better way to accomplish what we want.