### PR TITLE
Ignore additional non-HTML files

### DIFF
--- a/crawl.sh
+++ b/crawl.sh
@@ -62,7 +62,7 @@ time wget \
     --execute robots=off \
     --follow-tags=a \
     --limit-rate=1m \
-    --reject '*.css,*.csv,*.CSV,*.doc,*.docx,*.epub,*.gif,*.ico,*.jpg,*.js,*.mp3,*.pdf,*.PDF,*.png,*.pptx,*.tmp,*.txt,*.wav,*.woff,*.woff2,*.xls,*xlsx,*.xml,*.zip' \
+    --reject '*.css,*.csv,*.CSV,*.do,*.doc,*.docx,*.epub,*.gif,*.ico,*.jpg,*.js,*.mp3,*.pdf,*.PDF,*.png,*.pptx,*.py,*.R,*.sas,*.sps,*.tmp,*.txt,*.wav,*.woff,*.woff2,*.xls,*xlsx,*.xml,*.zip' \
     --reject-regex "topics=|authors=|categories=|filter_blog_category=|ext_url=|search_field=|issuer_name=" \
     --recursive \
     --level="$depth" \


### PR DESCRIPTION
Add these extensions to the reject list: .do, .py, .R, .sas, .sps