### PR TITLE
Run crawl with infinite depth

### DIFF
--- a/.github/workflows/crawl.yml
+++ b/.github/workflows/crawl.yml
@@ -17,7 +17,7 @@ jobs:
         run: rm -r www.consumerfinance.gov
 
       - name: Run the crawl script
-        run: ./crawl.sh -d 4 https://www.consumerfinance.gov
+        run: ./crawl.sh -d 0 https://www.consumerfinance.gov
 
       - name: Remove <script> tags and blank lines from crawl results
         run: ./transform_results.sh


### PR DESCRIPTION
Use wget with `--level=0` so that we crawl the entire website without limiting its depth.

This [succeeded on my fork](https://github.com/chosak/crawl-cfgov/actions/runs/346237020) and took 2 hr 42 minutes to run, resulting in a total of 12,560 files in the destination directory, including e.g. all 53 pages of the blog.