### PR TITLE
Improve summary by diffing all intended files

### DIFF
--- a/.github/workflows/crawl.yml
+++ b/.github/workflows/crawl.yml
@@ -6,6 +6,9 @@ on:
     - cron: '0 6 * * *'
   workflow_dispatch:
 
+env:
+  DOMAIN: www.consumerfinance.gov
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -14,22 +17,26 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Remove previous crawl results
-        run: rm -r www.consumerfinance.gov
+        run: rm -r ${{ env.DOMAIN }}
 
       - name: Run the crawl script
-        run: ./crawl.sh -d 0 https://www.consumerfinance.gov
+        run: ./crawl.sh -d 0 https://${{ env.DOMAIN }}
 
       - name: Remove <script> tags and blank lines from crawl results
-        run: ./transform_results.sh
+        run: ./transform_results.sh ${{ env.DOMAIN }}
         continue-on-error: true
 
+      - name: Prepare files for git commit
+        run: |
+          gzip -f *.log
+          git add *.log.gz
+          git add ${{ env.DOMAIN }}
+
       - name: Prepare commit message
-        run: ./generate_summary.sh
+        run: ./generate_summary.sh ${{ env.DOMAIN }}
 
       - name: Commit crawl results back to GitHub
         run: |
-          gzip -f *.log
-          git add .
           git config user.email actions@users.noreply.github.com
           git config user.name Automated
           git commit -F commit.txt

--- a/generate_summary.sh
+++ b/generate_summary.sh
@@ -1,7 +1,20 @@
 #!/usr/bin/env bash
 
+# Generate a friendly diff message for a set of HTML files.
+#
+# Exampleusage:
+#
+# ./generate_summary.sh path_to_html
+
 # If a command fails, stop executing this script and return its error code.
 set -e
+
+crawl_root=$1
+
+if [ -z "$crawl_root" ]; then
+    echo "Must specify path to HTML."
+    exit 1
+fi
 
 # Generate a summary of the crawl results into commit.txt
 date > commit.txt
@@ -10,4 +23,4 @@ lines  |lines  |
 added  |deleted|filename
 -------|-------|--------
 EOL
-git diff --numstat --no-color -- '*.html' >> commit.txt
+git diff --cached --numstat --no-color "$crawl_root" >> commit.txt


### PR DESCRIPTION
This change modifies the generate_summary.sh script so that it takes an argument that can be used to indicate which files to diff. Previously, only HTML files were being diffed, but due to long URLs, wget may download files that end in other extensions (see problem 2 at https://github.com/cfpb/crawl-cfgov/issues/13#issue-734794937).

Additionally, this changes the workflow file so that we only define the domain to crawl in a single place.