### PR TITLE
Prevent sed error in logs

### DIFF
--- a/transform_results.sh
+++ b/transform_results.sh
@@ -2,4 +2,4 @@
 
 # for each file in the www.consumerfinance.gov directory, run the given sed commands on it
 find www.consumerfinance.gov -type f \
-    -exec sed -f 'sed/remove_scripts.sed' -f 'sed/remove_blank_lines.sed' -i '' {} \;
+    -exec sed -f 'sed/remove_scripts.sed' -f 'sed/remove_blank_lines.sed' -i {} \;


### PR DESCRIPTION
Prevent the `sed: can't read : No such file or directory` error which is appearing in the GH Action logs in the "Remove <script> tags and blank lines from crawl results" step ([here's an example](https://github.com/cfpb/crawl-cfgov/runs/1356711538?check_suite_focus=true)).

GH Actions uses GNU sed, which has slightly different syntax from MacOS sed. For GNU sed, the -i flag does not take an argument.
