### PR TITLE
Improve commit messages with summary line

### DIFF
--- a/.github/workflows/crawl.yml
+++ b/.github/workflows/crawl.yml
@@ -33,7 +33,7 @@ jobs:
           git add ${{ env.DOMAIN }}
 
       - name: Prepare commit message
-        run: ./generate_summary.sh ${{ env.DOMAIN }}
+        run: ./generate_summary.sh ${{ env.DOMAIN }} > commit.txt
 
       - name: Commit crawl results back to GitHub
         run: |

--- a/generate_summary.sh
+++ b/generate_summary.sh
@@ -1,8 +1,9 @@
 #!/usr/bin/env bash
 
 # Generate a friendly diff message for a set of HTML files.
+# Changes must have already been staged using 'git add'.
 #
-# Exampleusage:
+# Example usage:
 #
 # ./generate_summary.sh path_to_html
 
@@ -16,11 +17,37 @@ if [ -z "$crawl_root" ]; then
     exit 1
 fi
 
-# Generate a summary of the crawl results into commit.txt
-date > commit.txt
-cat >> commit.txt <<EOL
-lines  |lines  |
-added  |deleted|filename
--------|-------|--------
-EOL
-git diff --cached --numstat --no-color "$crawl_root" >> commit.txt
+diff_cmd='git diff --cached --numstat --diff-filter=$diff_filter "$crawl_root"'
+heading="added  |deleted|filename\n-------|-------|--------"
+
+diff_filter=A
+added_result=`eval $diff_cmd`
+added_count=`eval $diff_cmd | wc -l | xargs`
+added_string="$added_count new"
+
+diff_filter=M
+changed_result=`eval $diff_cmd`
+changed_count=`eval $diff_cmd | wc -l | xargs`
+changed_string="$changed_count changed"
+
+diff_filter=D
+deleted_result=`eval $diff_cmd`
+deleted_count=`eval $diff_cmd | wc -l | xargs`
+deleted_string="$deleted_count removed"
+
+printf "$added_string, $changed_string, $deleted_string\n"
+
+if [[ $added_count -gt 0 ]]; then
+    printf "\n$added_string\n$heading\n"
+    printf "$added_result\n"
+fi
+
+if [[ $changed_count -gt 0 ]]; then
+    printf "\n$changed_string\n$heading\n"
+    printf "$changed_result\n"
+fi
+
+if [[ $deleted_count -gt 0 ]]; then
+    printf "\n$deleted_string\n$heading\n"
+    printf "$deleted_result\n"
+fi


### PR DESCRIPTION
Add a summary line to commit messages and split out added/changed/deleted files.

For example:

```
3 new, 1 changed, 3 removed

3 new:
added  |deleted|filename
-------|-------|--------
100	0	www.consumerfinance.gov/new-1/index.html
26	0	www.consumerfinance.gov/new-2/index.html
12	0	www.consumerfinance.gov/new-3/index.html

1 changed:
added  |deleted|filename
-------|-------|--------
3	3	www.consumerfinance.gov/changed/index.html

3 removed:
added  |deleted|filename
-------|-------|--------
100	0	www.consumerfinance.gov/removed-1/index.html
26	0	www.consumerfinance.gov/removed-2/index.html
12	0	www.consumerfinance.gov/removed-3/index.html
```

Fixes #21.
## Testing

Make some changes, `git add` them, and run this command:

```
./generate_summary.sh www.consumerfinance.gov
```