### PR TITLE
Don't archive filtered views of any collection

### DIFF
--- a/crawl.sh
+++ b/crawl.sh
@@ -70,7 +70,7 @@ time wget \
     --follow-tags=a \
     --limit-rate=1m \
     --reject '*.css,*.csv,*.CSV,*.do,*.doc,*.docx,*.epub,*.gif,*.ico,*.jpg,*.js,*.mp3,*.pdf,*.PDF,*.png,*.pptx,*.py,*.R,*.sas,*.sps,*.tmp,*.txt,*.wav,*.woff,*.woff2,*.xls,*xlsx,*.xml,*.zip' \
-    --reject-regex "topics=|authors=|categories=|filter_blog_category=|ext_url=|search_field=|issuer_name=" \
+    --reject-regex "topics=|authors=|categories=|filter_blog_category=|ext_url=|search_field=|issuer_name=|filter1_topics=" \
     --recursive \
     --level="$depth" \
     --trust-server-names \


### PR DESCRIPTION
The crawler visits URLs like this when we don't want it to: `www.consumerfinance.gov/about-us/blog/index.html?filter1_topics=ecoa`. You can [find those pages in the crawl results here](https://github.com/cfpb/crawl-cfgov/tree/82eda5e167b9188190e03003c08cc73ef1bfd66d/www.consumerfinance.gov/about-us/blog).

Instead we only want to visit pages with unique entries, so any whose only parameter is `page=X`.

## Additions

- Add `filter1_topics=` to the list of rejected URL patterns.
